### PR TITLE
Get zxcvbn from NPM instead of bower

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,6 +1,0 @@
-{
-  "predef": [
-    "console"
-  ],
-  "strict": false
-}

--- a/blueprints/ember-password-strength/index.js
+++ b/blueprints/ember-password-strength/index.js
@@ -1,9 +1,0 @@
-module.exports = {
-  normalizeEntityName: function () {
-    // this prevents an error when the entityName is not specified (since that doesn't actually matter to us)
-  },
-
-  afterInstall: function () {
-    return this.addBowerPackageToProject('zxcvbn', '4.3.0');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "ember-cli-password-strength",
-  "dependencies": {
-    "zxcvbn": "~4.3.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "ember-qunit-notifications": "0.1.0"
   }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,28 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
   name: 'ember-cli-password-strength',
 
-  included: function (app) {
+  included(app) {
     this._super.included.apply(this, arguments);
 
     if (typeof app.import !== 'function' && app.app) {
       app = app.app;
     }
-
-    app.import(app.bowerDirectory + '/zxcvbn/dist/zxcvbn.js');
+    app.import('vendor/zxcvbn.js');
     app.import('vendor/shims/password-strength.js');
-  }
+  },
+
+  treeForVendor(vendorTree) {
+    var zxcvbnTree = new Funnel(path.dirname(require.resolve('zxcvbn/dist/zxcvbn.js')), {
+      files: ['zxcvbn.js'],
+    });
+
+    return new MergeTrees([vendorTree, zxcvbnTree]);
+  },
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
     "zxcvbn"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "ember-cli-babel": "^5.1.6",
+    "zxcvbn": "^4.3.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Much more convenient for addon consumers as they don't have to manage
this dependency as well as being the path towards removing bower from ember-cli.

I *didn't* update the version of `zxcvbn` in the PR to limit the scope, but I can do that next or greenkeeper can take care of it now that it is in NPM.