### PR TITLE
Add sourcemap from NPM

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
 
   treeForVendor(vendorTree) {
     var zxcvbnTree = new Funnel(path.dirname(require.resolve('zxcvbn/dist/zxcvbn.js')), {
-      files: ['zxcvbn.js'],
+      files: ['zxcvbn.js', 'zxcvbn.js.map'],
     });
 
     return new MergeTrees([vendorTree, zxcvbnTree]);


### PR DESCRIPTION
I missed this in #59

Eliminates the message `Warning: ignoring input sourcemap for vendor/zxcvbn.js because ENOENT: no such file or directory`

Which shows up in consumers of this addon.